### PR TITLE
Fix signal handler error

### DIFF
--- a/src/indicator/python/ping-indicator-daemon.py
+++ b/src/indicator/python/ping-indicator-daemon.py
@@ -20,7 +20,7 @@ sys.path.append('/usr/share/ping-indicator/python/')
 PING_FREQUENCY = 1.0  # HZ
 
 
-def signal_handler():
+def signal_handler(signum, frame):
     global daemon
     daemon.quit()
     sys.exit(0)

--- a/src/indicator/python/ping-indicator-daemon.py
+++ b/src/indicator/python/ping-indicator-daemon.py
@@ -20,10 +20,17 @@ sys.path.append('/usr/share/ping-indicator/python/')
 PING_FREQUENCY = 1.0  # HZ
 
 
-def signal_handler(signum, frame):
-    global daemon
-    daemon.quit()
-    sys.exit(0)
+def init_signals(daemon):
+    """Catch signals to stop daemon before exiting."""
+
+    def signal_action(signum, frame):
+        """To be executed upon exit signal."""
+        daemon.quit()
+        sys.exit(0)
+
+    # catch signals and handle appropriately
+    for sig in [signal.SIGINT, signal.SIGHUP]:
+        signal.signal(sig, signal_action)
 
 
 def make_ping_object(h, ping_id):
@@ -115,11 +122,9 @@ if __name__ == "__main__":
     user = sys.argv[1]
 
     if len(user) > 0:
-        signal.signal(signal.SIGINT, signal_handler)
-        signal.signal(signal.SIGHUP, signal_handler)
-
         c = conf.Conf(user)
         PING_FREQUENCY = 1000.0 / c.refreshInterval
 
         daemon = PingIndicatorDaemon(c.servers, user)
+        init_signals(daemon)
         daemon.main()

--- a/src/indicator/python/ping.py
+++ b/src/indicator/python/ping.py
@@ -9,7 +9,7 @@
 
     Bugs are naturally mine. I'd be glad to hear about them. There are
     certainly word - size dependencies here.
-    
+
     :homepage: https://github.com/jedie/python-ping/
     :copyleft: 1989-2011 by the python-ping team, see AUTHORS for more details.
     :license: GNU GPL v2, see LICENSE for more details.


### PR DESCRIPTION
I noticed that if I ran `ping-indicator` or `/usr/share/ping-indicator/python/ping-indicator-daemon.py 1000` from the terminal, then killed the process, I received the following error:

> TypeError: signal_handler() takes no arguments (2 given)

The fix to this is just to add the arguments `signum` and `frame` to `signal_handler()`.

Also in case you're interested, I included a pattern I like to use when I've encountered this sort of situation in the past. Basically you just use a closure instead of global (cleaner IMHO, plus you're guaranteed that daemon will be there when you try to quit it) and a for loop to catch as many signals as you want.
