### PR TITLE
Support both: old python imaging and PIL

### DIFF
--- a/src/indicator/python/ping-indicator-gui.py
+++ b/src/indicator/python/ping-indicator-gui.py
@@ -5,7 +5,10 @@ import gtk
 import gtk.glade
 import appindicator
 import time
-import Image
+try:
+    import Image
+except ImportError:
+    from PIL import Image
 import os.path
 import subprocess
 import sys


### PR DESCRIPTION
On my machine with Ubuntu 18.04 the PIL also changed the package structure. 

    import Image

produces

    ImportError: No module named Image

So implement handling for both: old and new packages