### PR TITLE
Allow Low Refresh Rate for Low Network Consumption

### DIFF
--- a/src/indicator/python/data_exch.py
+++ b/src/indicator/python/data_exch.py
@@ -4,18 +4,21 @@
 
 import os
 import time
-
+import conf
 
 class Data_Exch:
+    
     def __init__(self, user):
         self.filename = os.path.expanduser("/tmp/ping-indicator-" + user + ".data")
+	self.user=user
 
     # self.read()
     def read(self):
+	c = conf.Conf(self.user)
         if os.path.exists(self.filename):
             t = int(time.time())
             delays = []
-            if t - int(os.path.getmtime(self.filename)) < 3:
+            if t - int(os.path.getmtime(self.filename)) < (2*c.refreshInterval/1000):
                 f = open(self.filename, "r")
                 for line in f:
                     parts = line.strip().split(':')

--- a/src/indicator/ui/conf.glade
+++ b/src/indicator/ui/conf.glade
@@ -110,9 +110,9 @@
               <widget class="GtkHScale" id="interval__hscale">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
-                <property name="adjustment">100 100 2000 50 200 500</property>
+                <property name="adjustment">100 100 3600000 50 200 500</property>
                 <property name="lower_stepper_sensitivity">on</property>
-                <property name="fill_level">5000</property>
+                <property name="fill_level">3600000</property>
                 <property name="round_digits">50</property>
                 <property name="value_pos">right</property>
               </widget>


### PR DESCRIPTION
At least the commit that calculate the No fresh data alert based on the config file (and not arbitrary 3s).

Maybe the UI change to allow a 1h refresh rate (3600000 ms)